### PR TITLE
Fix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ $ yarn add @datalust/winston-seq winston
 
 ```ts
 const winston = require('winston');
-const SeqTransport = require('@datalust/winston-seq');
+const { SeqTransport } = require('@datalust/winston-seq');
+// or import { SeqTransport } from '@datalust/winston-seq';
 
 const logger = winston.createLogger({
   level: 'info',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datalust/winston-seq",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "description": "A Winston v3 transport for Seq",
   "author": "Datalust and contributors",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "description": "A Winston v3 transport for Seq",
   "author": "Datalust and contributors",
-  "module": "dist/index.js",
+  "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "build": "tsc",
@@ -23,9 +23,12 @@
     "preset": "ts-jest",
     "testEnvironment": "node"
   },
+  "peerDependencies": {
+    "winston": "^3.0.0"
+  },
   "dependencies": {
     "seq-logging": "^1.1.1",
-    "winston-transport": "^4.4.0"
+    "winston-transport": "^4.0.0"
   },
   "devDependencies": {
     "@tsconfig/recommended": "^1.0.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import TransportStream from 'winston-transport'
  * Inherit from `winston-transport` so you can take advantage
  * of the base functionality and `.exceptions.handle()`.
  */
-class SeqTransport extends TransportStream {
+export class SeqTransport extends TransportStream {
   public logger: seq.Logger
 
   constructor (opts: seq.SeqLoggerConfig
@@ -52,8 +52,6 @@ class SeqTransport extends TransportStream {
     return this.logger.flush();
   }
 }
-
-export default SeqTransport
 
 if (!String.prototype.startsWith) {
   Object.defineProperty(String.prototype, 'startsWith', {

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,10 +1,10 @@
 /* eslint-disable jest/expect-expect */
 import winston from 'winston'
-import winstonSeq from '../src/index'
+import { SeqTransport } from '../src/index'
 const axios = require('axios').default;
 require('dotenv').config()
 
-let logger: winston.Logger, transport: winstonSeq
+let logger: winston.Logger, transport: SeqTransport
 
 describe('winston-seq', () => {
   beforeAll(() => {
@@ -18,7 +18,7 @@ describe('winston-seq', () => {
       throw new Error('Seq required')
     }
 
-    transport = new winstonSeq({
+    transport = new SeqTransport({
       serverUrl: process.env.SEQ_INGESTION_URL,
       apiKey: process.env.SEQ_API_KEY,
       onError: (e => { console.error(e) }),
@@ -99,7 +99,7 @@ describe('winston-seq', () => {
 
   it('should work with different formats', async ()=>{
     const random = getRandom();
-    const diffFormatTransport = new winstonSeq({
+    const diffFormatTransport = new SeqTransport({
       serverUrl: process.env.SEQ_INGESTION_URL,
       apiKey: process.env.SEQ_API_KEY,
       onError: (e => { console.error(e) }),
@@ -130,7 +130,7 @@ describe('winston-seq', () => {
 
   it('should work with no API key', async ()=>{
     const random = getRandom();
-    const anonTransport = new winstonSeq({
+    const anonTransport = new SeqTransport({
       serverUrl: process.env.SEQ_INGESTION_URL,
       onError: (e => { console.error(e) }),
       handleExceptions: true,


### PR DESCRIPTION
Changed to exporting an object so that CommonJS usage doesn't have to be `require('@datalust/winston-seq').default;`

Changed a property in package.json from `module` to `main` so that the node imported can find the module.